### PR TITLE
Fixed #8 path to procfs is now confugurable

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,12 +1,20 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-load",
-	"GoVersion": "go1.5",
-	"GodepVersion": "v63",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v62",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
-			"Comment": "v0.7.3",
-			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
+			"Comment": "v0.10.0-16-gcd7d1bb",
+			"Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/config",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/ns",
+			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/str",
@@ -14,63 +22,72 @@
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-77-g5c1177e",
-			"Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/oleiade/reflections",
+			"Comment": "0.1.2-2-g632977f",
+			"Rev": "632977f98cd34d217c4b57d0840ec188b3d3dcaf"
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
-			"Comment": "v1-7-g32d9c27",
-			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
+			"Comment": "v1-16-g0f39cf7",
+			"Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "c8bc69bc2db9c57ccf979550bc69655df5039a8a"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This builds the plugin in `/build/rootfs/`
 
 Plugin may be additionally configured with path to `/proc/loadavg` file. It may be useful for running plugin in Docker container.
 Example configuration provided in [Examples](https://github.com/intelsdi-x/snap-plugin-collector-load/blob/master/README.md#examples)
-In case configuration is not provided in task manifest, plugin will use default path `/proc/laodavg`
+In case configuration is not provided in task manifest, plugin will use default path `/proc/loadavg`
 
 
 ## Documentation
@@ -106,7 +106,7 @@ Create a task manifest file (exemplary file in [examples/task/] (https://github.
             },
             "config": {
                 "/intel/procfs/load/": {
-                    "procfs_path": "/var/procfs/loadavg"
+                    "proc_path": "/var/procfs/loadavg"
                 }
             },
             "process": [

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ This builds the plugin in `/build/rootfs/`
 `export SNAP_PATH=$GOPATH/src/github.com/intelsdi-x/snap/build`
 * Load the plugin and create a task, see example in [Examples](https://github.com/intelsdi-x/snap-plugin-collector-load/blob/master/README.md#examples).
 
+Plugin may be additionally configured with path to `/proc/loadavg` file. It may be useful for running plugin in Docker container.
+Example configuration provided in [Examples](https://github.com/intelsdi-x/snap-plugin-collector-load/blob/master/README.md#examples)
+In case configuration is not provided in task manifest, plugin will use default path `/proc/laodavg`
+
+
 ## Documentation
 
 ### Collected Metrics
@@ -58,7 +63,11 @@ Namespace | Description (optional)
 /intel/procfs/load/min1 | number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 1 minute
 /intel/procfs/load/min5 | number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 5 minutes
 /intel/procfs/load/min15 | number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 15 minutes
-/intel/procfs/load/scheduling | Two numbers separated by a slash (/). The first is the number of currently runnable kernel scheduling entities (processes, threads). The second is the number of kernel scheduling entities that currently exist on the system
+/intel/procfs/load/min1_rel | number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 1 minute per core
+/intel/procfs/load/min5_rel | number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 5 minutes per core
+/intel/procfs/load/min15_rel | number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 15 minutes per core
+/intel/procfs/load/runnable_scheduling | The number of currently runnable kernel scheduling entities (processes, threads).
+/intel/procfs/load/existing_scheduling | The number of kernel scheduling entities that currently exist on the system
 
 ### Examples
 Example running load, passthru processor, and writing data to a file.
@@ -96,9 +105,8 @@ Create a task manifest file (exemplary file in [examples/task/] (https://github.
                 "/intel/procfs/load/scheduling": {}
             },
             "config": {
-                "/intel/mock": {
-                    "password": "secret",
-                    "user": "root"
+                "/intel/procfs/load/": {
+                    "procfs_path": "/var/procfs/loadavg"
                 }
             },
             "process": [

--- a/examples/task/load-file.json
+++ b/examples/task/load-file.json
@@ -12,9 +12,8 @@
                 "/intel/procfs/load/scheduling": {}
             },
             "config": {
-                "/intel/mock": {
-                    "password": "secret",
-                    "user": "root"
+                "/intel/procfs/load/": {
+                    "proc_path": "/var/procfs/loadavg"
                 }
             },
             "process": [

--- a/load/load.go
+++ b/load/load.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,42 +22,35 @@ limitations under the License.
 package load
 
 import (
-	"bufio"
 	"fmt"
-	"os"
+	"io/ioutil"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap-plugin-utilities/str"
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core"
+
+	"github.com/intelsdi-x/snap-plugin-utilities/config"
+	"github.com/intelsdi-x/snap-plugin-utilities/ns"
 )
 
 const (
 	// VENDOR namespace part
-	VENDOR = "intel"
+	pluginVendor = "intel"
 	// FS namespace part
-	FS = "procfs"
+	fs = "procfs"
 	// PLUGIN namespace part
-	PLUGIN = "load"
+	pluginName = "load"
 	// VERSION of load info plugin
-	VERSION = 2
+	pluginVersion = 3
 )
-
-var loadInfo = "/proc/loadavg"
-
-type loadPlugin struct {
-	stats map[string]interface{}
-	cpus  int
-}
-
-type infoFields struct {
-	description string
-	unit        string
-}
 
 var pluginInfoFields = map[string]infoFields{
 	"min1": infoFields{
@@ -72,30 +65,125 @@ var pluginInfoFields = map[string]infoFields{
 		description: "number of jobs in the run queue (state R) or waiting for disk I/O (state D) averaged over 15 minutes",
 		unit:        "",
 	},
-	"scheduling": infoFields{
-		description: "Two numbers separated by a slash (/). The first is the number of currently runnable kernel scheduling entities (processes, threads). The second is the number of kernel scheduling entities that currently exist on the system",
+	"runnable_scheduling": infoFields{
+		description: "The number of currently runnable kernel scheduling entities (processes, threads)",
+		unit:        "",
+	},
+	"existing_scheduling": infoFields{
+		description: "The number of kernel scheduling entities that currently exist on the system",
 		unit:        "",
 	},
 }
 
 // New create instance of load info plugin
 func New() *loadPlugin {
-	fh, err := os.Open(loadInfo)
-
-	if err != nil {
-		return nil
-	}
-	defer fh.Close()
-
+	logger := log.New()
 	cpu, err := getCPUs()
-
 	if err != nil {
+		logger.Errorf("Error while reading number of cpus {%s}", err)
 		return nil
 	}
 
-	mp := &loadPlugin{stats: map[string]interface{}{}, cpus: cpu}
+	lp := &loadPlugin{cpus: cpu, logger: logger}
+	lp.logger.Debug("New plugin instance created")
+	return lp
+}
 
-	return mp
+// Meta returns plugin meta data
+func Meta() *plugin.PluginMeta {
+	return plugin.NewPluginMeta(
+		pluginName,
+		pluginVersion,
+		plugin.CollectorPluginType,
+		[]string{},
+		[]string{plugin.SnapGOBContentType},
+		plugin.ConcurrencyCount(1),
+	)
+}
+
+// GetMetricTypes returns list of available metric types
+// It returns error in case retrieval was not successful
+func (lp *loadPlugin) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error) {
+	lp.logger.Debug("Calling GetMetricTypes()")
+	stats := LoadMetrics{}
+	namespaces := []string{}
+	metricTypes := []plugin.MetricType{}
+
+	ns.FromCompositionTags(stats, strings.Join([]string{pluginVendor, fs, pluginName}, "/"), &namespaces)
+	lp.logger.Debugf("Namespaces created %v", namespaces)
+
+	for _, namespace := range namespaces {
+		last := path.Base(namespace)
+		info := getInfoFields(last)
+		metricType := plugin.MetricType{
+			Namespace_:   core.NewNamespace(strings.Split(namespace, "/")...),
+			Description_: info.description,
+			Unit_:        info.unit,
+			Config_:      cfg.ConfigDataNode,
+		}
+		metricTypes = append(metricTypes, metricType)
+		lp.logger.Debugf("MetricType created successfully %s", metricType.Namespace().String())
+	}
+
+	return metricTypes, nil
+}
+
+// CollectMetrics returns list of requested metric values
+// It returns error in case retrieval was not successful
+func (lp *loadPlugin) CollectMetrics(metricTypes []plugin.MetricType) ([]plugin.MetricType, error) {
+	lp.logger.Debug("Calling CollectMetrics()")
+	metrics := []plugin.MetricType{}
+	stats := LoadMetrics{}
+
+	// get location of loadavg
+	procFilePath, _ := config.GetConfigItem(metricTypes[0], "procfs_path")
+	lp.logger.Debugf("Procfs loadavg location found %s", procFilePath.(string))
+
+	// read metrics from provided loadavg loacation
+	if err := getStats(procFilePath.(string), &stats, lp.cpus); err != nil {
+		lp.logger.Errorf("Could not read metrics from %s location. {%s}", procFilePath.(string), err)
+		return nil, err
+	}
+
+	for _, metricType := range metricTypes {
+		namespace := metricType.Namespace()
+		if len(namespace.Strings()) < 4 {
+			lp.logger.Errorf("Namespace length is too short (len = %d)", len(namespace.Strings()))
+			return nil, fmt.Errorf("Namespace length is too short (len = %d)", len(namespace.Strings()))
+		}
+
+		val := ns.GetValueByNamespace(stats, namespace.Strings()[3:])
+		lp.logger.Debugf("Found value %v for %s", val, namespace.String())
+		metric := plugin.MetricType{
+			Namespace_: namespace,
+			Data_:      val,
+			Timestamp_: time.Now(),
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}
+
+// GetConfigPolicy returns config policy
+// It returns error in case retrieval was not successful
+func (lp *loadPlugin) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	cp := cpolicy.New()
+	lp.logger.Debug("Creating new rule for procfs_path")
+	rule, _ := cpolicy.NewStringRule("procfs_path", false, "/proc/loadavg")
+	node := cpolicy.NewPolicyNode()
+	node.Add(rule)
+	cp.Add([]string{pluginVendor, fs, pluginName}, node)
+	return cp, nil
+}
+
+type loadPlugin struct {
+	cpus   int
+	logger *log.Logger
+}
+
+type infoFields struct {
+	description string
+	unit        string
 }
 
 func getCPUs() (int, error) {
@@ -118,97 +206,52 @@ func getCPUs() (int, error) {
 	return cpus + 1, nil
 }
 
-func getStats(stats map[string]interface{}, cpus int) error {
-	fh, err := os.Open(loadInfo)
-
+func getStats(procFilePath string, stats *LoadMetrics, cpus int) error {
+	content, err := ioutil.ReadFile(procFilePath)
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
 
-	scanner := bufio.NewScanner(fh)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
+	fields := strings.Fields(string(content))
 
-		if len(fields) < 5 {
-			return fmt.Errorf("Wrong %s format", loadInfo)
-		}
+	if len(fields) < 5 {
+		return fmt.Errorf("Wrong %s format", string(content))
+	}
 
-		min1, err := strconv.ParseFloat(fields[0], 64)
-		if err != nil {
-			return err
-		}
-		stats["min1"] = min1
-		stats["min1_rel"] = min1 / float64(cpus)
+	stats.Min1, err = strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return err
+	}
+	stats.Min1Rel = stats.Min1 / float64(cpus)
 
-		min5, err := strconv.ParseFloat(fields[1], 64)
-		if err != nil {
-			return err
-		}
-		stats["min5"] = min5
-		stats["min5_rel"] = min5 / float64(cpus)
+	stats.Min5, err = strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return err
+	}
+	stats.Min5Rel = stats.Min5 / float64(cpus)
 
-		min15, err := strconv.ParseFloat(fields[2], 64)
-		if err != nil {
-			return err
-		}
-		stats["min15"] = min15
-		stats["min15_rel"] = min15 / float64(cpus)
+	stats.Min15, err = strconv.ParseFloat(fields[2], 64)
+	if err != nil {
+		return err
+	}
+	stats.Min15Rel = stats.Min15 / float64(cpus)
 
-		stats["scheduling"] = fields[3]
+	scheduling := strings.Split(fields[3], "/")
+	if len(scheduling) != 2 {
+		return fmt.Errorf("Scheduling data format incorrect {%s}", fields[3])
+	}
+
+	stats.RunSched, err = strconv.Atoi(scheduling[0])
+	if err != nil {
+		return err
+	}
+
+	stats.ExistingSched, err = strconv.Atoi(scheduling[1])
+	if err != nil {
+		return err
 	}
 
 	return nil
-}
-
-// GetMetricTypes returns list of available metric types
-// It returns error in case retrieval was not successful
-func (mp *loadPlugin) GetMetricTypes(_ plugin.ConfigType) ([]plugin.MetricType, error) {
-	metricTypes := []plugin.MetricType{}
-	if err := getStats(mp.stats, mp.cpus); err != nil {
-		return nil, err
-	}
-	for stat := range mp.stats {
-		info := getInfoFields(stat)
-		metricType := plugin.MetricType{
-			Namespace_:   core.NewNamespace(VENDOR, FS, PLUGIN, stat),
-			Description_: info.description,
-			Unit_:        info.unit,
-		}
-		metricTypes = append(metricTypes, metricType)
-	}
-	return metricTypes, nil
-}
-
-// CollectMetrics returns list of requested metric values
-// It returns error in case retrieval was not successful
-func (mp *loadPlugin) CollectMetrics(metricTypes []plugin.MetricType) ([]plugin.MetricType, error) {
-	metrics := []plugin.MetricType{}
-	getStats(mp.stats, mp.cpus)
-	for _, metricType := range metricTypes {
-		ns := metricType.Namespace()
-		if len(ns) < 4 {
-			return nil, fmt.Errorf("Namespace length is too short (len = %d)", len(ns))
-		}
-		stat := ns[3]
-		val, ok := mp.stats[stat.Value]
-		if !ok {
-			return nil, fmt.Errorf("Requested stat %s is not available!", stat)
-		}
-		metric := plugin.MetricType{
-			Namespace_: ns,
-			Data_:      val,
-			Timestamp_: time.Now(),
-		}
-		metrics = append(metrics, metric)
-	}
-	return metrics, nil
-}
-
-// GetConfigPolicy returns config policy
-// It returns error in case retrieval was not successful
-func (mp *loadPlugin) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
-	return cpolicy.New(), nil
 }
 
 func getInfoFields(metric string) infoFields {

--- a/load/load.go
+++ b/load/load.go
@@ -136,12 +136,12 @@ func (lp *loadPlugin) CollectMetrics(metricTypes []plugin.MetricType) ([]plugin.
 	stats := LoadMetrics{}
 
 	// get location of loadavg
-	procFilePath, _ := config.GetConfigItem(metricTypes[0], "procfs_path")
-	lp.logger.Debugf("Procfs loadavg location found %s", procFilePath.(string))
+	procPath, _ := config.GetConfigItem(metricTypes[0], "proc_path")
+	lp.logger.Debugf("Procfs loadavg location found %s", procPath.(string))
 
 	// read metrics from provided loadavg loacation
-	if err := getStats(procFilePath.(string), &stats, lp.cpus); err != nil {
-		lp.logger.Errorf("Could not read metrics from %s location. {%s}", procFilePath.(string), err)
+	if err := getStats(procPath.(string), &stats, lp.cpus); err != nil {
+		lp.logger.Errorf("Could not read metrics from %s location. {%s}", procPath.(string), err)
 		return nil, err
 	}
 
@@ -168,8 +168,8 @@ func (lp *loadPlugin) CollectMetrics(metricTypes []plugin.MetricType) ([]plugin.
 // It returns error in case retrieval was not successful
 func (lp *loadPlugin) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	cp := cpolicy.New()
-	lp.logger.Debug("Creating new rule for procfs_path")
-	rule, _ := cpolicy.NewStringRule("procfs_path", false, "/proc/loadavg")
+	lp.logger.Debug("Creating new rule for proc_path")
+	rule, _ := cpolicy.NewStringRule("proc_path", false, "/proc")
 	node := cpolicy.NewPolicyNode()
 	node.Add(rule)
 	cp.Add([]string{pluginVendor, fs, pluginName}, node)
@@ -206,8 +206,8 @@ func getCPUs() (int, error) {
 	return cpus + 1, nil
 }
 
-func getStats(procFilePath string, stats *LoadMetrics, cpus int) error {
-	content, err := ioutil.ReadFile(procFilePath)
+func getStats(procPath string, stats *LoadMetrics, cpus int) error {
+	content, err := ioutil.ReadFile(path.Join(procPath, "loadavg"))
 	if err != nil {
 		return err
 	}

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -48,12 +48,12 @@ func (lis *LoadInfoSuite) SetupSuite() {
 	lis.min15 = 0.16
 	lis.runsch = 1
 	lis.existsch = 100
-	lis.MockLoadInfo = "mockLoadInfo"
-	createMockLoadInfo(lis.MockLoadInfo, lis.min1, lis.min5, lis.min15, lis.runsch, lis.existsch, 1111)
+	lis.MockLoadInfo = "."
+	createMockLoadInfo("loadavg", lis.min1, lis.min5, lis.min15, lis.runsch, lis.existsch, 1111)
 }
 
 func (lis *LoadInfoSuite) TearDownSuite() {
-	removeMockLoadInfo(lis.MockLoadInfo)
+	removeMockLoadInfo("loadavg")
 }
 
 func (lis *LoadInfoSuite) TestGetStats() {
@@ -61,7 +61,7 @@ func (lis *LoadInfoSuite) TestGetStats() {
 		stats := LoadMetrics{}
 
 		Convey("and mock memory info file created", func() {
-			assert.Equal(lis.T(), "mockLoadInfo", lis.MockLoadInfo)
+			assert.Equal(lis.T(), ".", lis.MockLoadInfo)
 		})
 
 		Convey("When reading load statistics from file", func() {
@@ -125,7 +125,7 @@ func (lis *LoadInfoSuite) TestCollectMetrics() {
 
 		Convey("When one wants to get values for given metric types", func() {
 			cfg := plugin.NewPluginConfigType()
-			cfg.AddItem("procfs_path", ctypes.ConfigValueStr{lis.MockLoadInfo})
+			cfg.AddItem("proc_path", ctypes.ConfigValueStr{lis.MockLoadInfo})
 			mTypes := []plugin.MetricType{
 				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "load", "min1"), Config_: cfg.ConfigDataNode},
 				plugin.MetricType{Namespace_: core.NewNamespace("intel", "procfs", "load", "runnable_scheduling"), Config_: cfg.ConfigDataNode},

--- a/load/metrics.go
+++ b/load/metrics.go
@@ -1,0 +1,42 @@
+// +build linux
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package load
+
+// LoadMetrics stores load average figures of the system
+type LoadMetrics struct {
+	// Min1 is load average the number of jobs in the run queue or waiting for disk I/O averaged over 1 minute
+	Min1 float64 `json:"min1"`
+	// Min5 is load average the number of jobs in the run queue or waiting for disk I/O averaged over 5 minutes
+	Min5 float64 `json:"min5"`
+	// Min15 is load average the number of jobs in the run queue or waiting for disk I/O averaged over 15 minutes
+	Min15 float64 `json:"min15"`
+	// Min1 is load average the number of jobs in the run queue or waiting for disk I/O averaged over 1 minute per core
+	Min1Rel float64 `json:"min1_rel"`
+	// Min5 is load average the number of jobs in the run queue or waiting for disk I/O averaged over 5 minutes per core
+	Min5Rel float64 `json:"min5_rel"`
+	// Min15 is load average the number of jobs in the run queue or waiting for disk I/O averaged over 15 minutes per core
+	Min15Rel float64 `json:"min15_rel"`
+	// RunSched is the number of currently runnable kernel scheduling entities
+	RunSched int `json:"runnable_scheduling"`
+	// ExistingSched the number of kernel scheduling entities that currently exist on the system
+	ExistingSched int `json:"existing_scheduling"`
+}

--- a/main.go
+++ b/main.go
@@ -36,13 +36,7 @@ func main() {
 	}
 
 	plugin.Start(
-		plugin.NewPluginMeta(
-			load.PLUGIN,
-			load.VERSION,
-			plugin.CollectorPluginType,
-			[]string{},
-			[]string{plugin.SnapGOBContentType},
-			plugin.ConcurrencyCount(1)),
+		load.Meta(),
 		loadPlugin,
 		os.Args[1],
 	)


### PR DESCRIPTION
- "procfs_path" added as configuration item, with default value "/procfs/loadavg"
- namespace is now build staticaly, without reading the file
- updated unit tests