### PR TITLE
Project directory properly set in large tests

### DIFF
--- a/scripts/docker/large/docker-compose.yml
+++ b/scripts/docker/large/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: mkrolik/spytest:lscpu
     network_mode: "host"
     volumes:
-      - ${PLUGIN_SRC}:/snap-plugin-collector-load
+      - ${PLUGIN_SRC}:/${PROJECT_NAME}
       - /proc:/var/procfs
     entrypoint: sh -c 'python /snap-plugin-collector-load/scripts/test/large.py'
+    environment:
+      PROJECT_DIR: /${PROJECT_NAME}

--- a/scripts/large_k8s.sh
+++ b/scripts/large_k8s.sh
@@ -41,12 +41,12 @@ while ! [ "$(kubectl get po --no-headers | grep $__deployment_name | grep Runnin
     sleep 5
 done
 _debug "copying the src into the runner"
-kubectl exec $(kubectl get po --no-headers | grep $__deployment_name | grep Running | awk '{print $1}') -c load-large-test -i  -- mkdir /src
-tar c  . | kubectl exec $(kubectl get po --no-headers | grep $__deployment_name | grep Running | awk '{print $1}') -c load-large-test -i  --  tar -x -C /src
+kubectl exec $(kubectl get po --no-headers | grep $__deployment_name | grep Running | awk '{print $1}') -c load-large-test -i  -- mkdir /tmp/src
+tar c  . | kubectl exec $(kubectl get po --no-headers | grep $__deployment_name | grep Running | awk '{print $1}') -c load-large-test -i  --  tar -x -C /tmp/src
 
 set +e
 _debug "running tests through the runner"
-kubectl exec $(kubectl get po --no-headers | grep $__deployment_name | grep Running | awk '{print $1}') -c load-large-test -i -- /src/scripts/large_test.sh
+kubectl exec $(kubectl get po --no-headers | grep $__deployment_name | grep Running | awk '{print $1}') -c load-large-test -i -- /tmp/src/scripts/large_test.sh
 test_res=$?
 set -e
 _debug "exit code $test_res"

--- a/scripts/large_test.sh
+++ b/scripts/large_test.sh
@@ -27,7 +27,7 @@ __proj_name="$(basename $__proj_dir)"
 
 . "${__dir}/common.sh"
 
-export PROJECT_NAME="${__proj_name}"
+export PROJECT_DIR="${__proj_dir}"
 
 _info "execute large test"
 test_result=`python "${__proj_dir}/scripts/test/large.py"`

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -47,8 +47,8 @@ class LoadCollectorLargeTest(unittest.TestCase):
 
         utils.download_binaries(self.binaries)
 
-        self.task_file = "/{}/examples/tasks/task-load.json".format(
-            os.getenv("PROJECT_NAME", "snap-plugin-collector-load"))
+        self.task_file = "{}/examples/tasks/task-load.json".format(
+            os.getenv("PROJECT_DIR", "snap-plugin-collector-load"))
 
         log.info("starting snapd")
         self.binaries.snapd.start()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes incorrect handling of project directory in large tests on K8S

Summary of changes:
- setting env in docker compose
- setting path in large test

How to verify it:
- run large test on local k8s

Testing done:
- large test

